### PR TITLE
Fix symbolic link handling

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,9 +2,10 @@ name: ubuntu
 
 on:
   - push
+  - workflow_dispatch
 
 jobs:
-  build:
+  build-on-ubuntu:
     strategy:
       fail-fast: false
       matrix:
@@ -51,3 +52,46 @@ jobs:
       - name: Output deb package versions
         if: always()
         run: dpkg -l
+  build-on-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+          - 3.2
+          - 3.1
+          - "3.0"
+          - 2.7
+          - 2.6
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache rubygems
+        uses: actions/cache@v3.2.2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-rubygems-${{ matrix.ruby_version }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('**/*.gemspec') }}
+          restore-keys: |
+            ${{ runner.os }}-rubygems-${{ matrix.ruby_version }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+      - name: Install dependencies
+        run: |
+          set -eux
+          gem update --system
+          bundle config path vendor/bundle
+          bundle install --jobs $(sysctl -n hw.logicalcpu) --retry 3
+      - name: Run rake
+        run: bundle exec rake
+      - name: Output versions
+        if: always()
+        run: |
+          set -eux
+          uname -a
+          ruby --version
+          gem --version
+          bundle --version
+      - name: Output gem versions
+        if: always()
+        run: bundle list

--- a/lib/dpu.rb
+++ b/lib/dpu.rb
@@ -17,7 +17,8 @@ module Dpu
       Regexp.union(*patterns)
     }
 
-    def determine_permanent_uri(path, start_line_number = nil, end_line_number = nil)
+    def determine_permanent_uri(path_or_link, start_line_number = nil, end_line_number = nil)
+      path = path_or_link.realpath
       relative_path = determine_relative_path(path)
 
       permanent_uri_parts = [


### PR DESCRIPTION
On macOS, the `/tmp` and `/var` and `/etc` directories are symbolic links to the `/private` directory. The current dpu implementation does not handle symbolic links, which has caused problems, especially in testing.

Therefore, we have modified the part that determines the path to get the path of the entity in case of a symbolic link.