### PR TITLE
Handle malformed versions and use ascii only tag for url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 13.0"
+
+gem "version_sorter", "~> 2.3"

--- a/test/unit/dpu_test.rb
+++ b/test/unit/dpu_test.rb
@@ -100,6 +100,34 @@ class DpuTest < Test::Unit::TestCase
         )
       end
     end
+
+    test("malformed version tag can be handled") do
+      remote_url = "git@github.com:foo_account_name/bar_repository_name.git"
+      create_repository(remote_url) do |repository_path|
+        file_path = repository_path / "file.txt"
+        file_path.open("a") do |f|
+          f.puts("additional text")
+        end
+        commit_all_files(repository_path)
+        tag("日本語", repository_path)
+
+        other_file_path = repository_path / "other_file_to_change_commit_id.txt"
+        other_file_path.write("test\n")
+        commit_all_files(repository_path)
+        tag("1.0.0⚪︎", repository_path)
+
+        commit_id = fetch_commit_id(repository_path)
+
+        assert_equal(
+          URI("https://github.com/foo_account_name/bar_repository_name/blob/#{commit_id}/file.txt"),
+          Dpu.determine_permanent_uri(file_path),
+        )
+        assert_equal(
+          URI("https://github.com/foo_account_name/bar_repository_name/blob/#{commit_id}/other_file_to_change_commit_id.txt"),
+          Dpu.determine_permanent_uri(other_file_path),
+        )
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Versions like `日本語` or `1.0.0⚪︎` are valid for Git, but Gem::Version cannot handle them, so there was an error in the version sorting logic. So, I introduced version_sorter to avoid the error.

However, this may cause non-ascii strings to be included in the URI as the version, so we added logic to determine this.